### PR TITLE
Boto3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/test.db
 coverage.xml
 htmlcov
 *.sw?
+rigor.ini

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -4,8 +4,9 @@ from abc import ABCMeta, abstractmethod
 from io import BytesIO
 import sys
 try:
-	import boto3
-	import botocore
+ 	from boto3 import session
+	from boto3 import resource
+	from botocore.exceptions import ClientError
 except ImportError:
 	from boto.s3.connection import S3Connection
 	from boto.s3.key import Key
@@ -80,11 +81,11 @@ class BotoS3Client(RigorS3Client):
 		super(BotoS3Client, self).__init__(config, bucket, credentials)
 		if 'boto3' in sys.modules:
 			if credentials:
-				session = boto3.session.Session(aws_access_key_id=config.get(credentials, 'aws_access_key_id'),
+				boto3session = session.Session(aws_access_key_id=config.get(credentials, 'aws_access_key_id'),
 												aws_secret_access_key=config.get(credentials, 'aws_secret_access_key'))
-				self._conn = session.resource('s3')
+				self._conn = boto3session.resource('s3')
 			else:
-				self._conn = boto3.resource('s3')
+				self._conn = resource('s3')
 
 			self.bucket = self._conn.Bucket(bucket)
 		else:
@@ -155,7 +156,7 @@ class BotoS3Client(RigorS3Client):
 			else:
 				self.bucket.download_file(key, local_file)
 				return True
-		except botocore.exceptions.ClientError as e:
+		except ClientError as e:
 			return None
 
 		return s3_obj

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -5,13 +5,11 @@ from io import BytesIO
 import sys
 try:
 	import boto3
+	import botocore
 except ImportError:
 	from boto.s3.connection import S3Connection
 	from boto.s3.key import Key
 
-
-
-import botocore
 
 
 class RigorS3Client(object):
@@ -148,6 +146,8 @@ class BotoS3Client(RigorS3Client):
 			This implementation is speicfic to Boto3
 		"""
 		s3_obj = BytesIO()
+		if key[:1] == '/':
+			key = key.lstrip('/')
 		try:
 			if local_file is None:
 				self.bucket.download_fileobj(key, s3_obj)
@@ -164,6 +164,8 @@ class BotoS3Client(RigorS3Client):
 		""" See :py:meth:`RigorS3Client.put` 
 			This implementation is specific to Boto3
 		"""
+		if key[:1] == '/':
+			key = key.lstrip('/')
 		if hasattr(data, 'read'):
 			self.bucket.upload_fileobj(data, key)
 		else:

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -6,11 +6,9 @@ import sys
 try:
 	import boto3
 except ImportError:
-	try:
-		from boto.s3.connection import S3Connection
-		from boto.s3.key import Key
-	except ImportError:
-		print("ignore")
+	from boto.s3.connection import S3Connection
+	from boto.s3.key import Key
+
 
 
 import botocore
@@ -24,7 +22,6 @@ class RigorS3Client(object):
 	:type config: :py:class:`~rigor.config.RigorConfiguration`
 	:param str bucket: S3 bucket containing data
 	:param str credentials: name of credentials section
-	:param str session: the s3 session if one exists.
 	"""
 	__metaclass__ = ABCMeta
 
@@ -58,7 +55,7 @@ class RigorS3Client(object):
 
 	@abstractmethod
 	def delete(self, key):
-		"""sudo 
+		"""
 		Removes data at the given key from S3
 
 		:param str key: S3 key for the object to delete

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -2,8 +2,19 @@
 
 from abc import ABCMeta, abstractmethod
 from io import BytesIO
-from boto.s3.connection import S3Connection
-from boto.s3.key import Key
+import sys
+try:
+	import boto3
+except ImportError:
+	try:
+		from boto.s3.connection import S3Connection
+		from boto.s3.key import Key
+	except ImportError:
+		print("ignore")
+
+
+import botocore
+
 
 class RigorS3Client(object):
 	"""
@@ -13,6 +24,7 @@ class RigorS3Client(object):
 	:type config: :py:class:`~rigor.config.RigorConfiguration`
 	:param str bucket: S3 bucket containing data
 	:param str credentials: name of credentials section
+	:param str session: the s3 session if one exists.
 	"""
 	__metaclass__ = ABCMeta
 
@@ -46,7 +58,7 @@ class RigorS3Client(object):
 
 	@abstractmethod
 	def delete(self, key):
-		"""
+		"""sudo 
 		Removes data at the given key from S3
 
 		:param str key: S3 key for the object to delete
@@ -75,11 +87,24 @@ class BotoS3Client(RigorS3Client):
 		if credentials:
 			connection_args.append(config.get(credentials, 'aws_access_key_id'))
 			connection_args.append(config.get(credentials, 'aws_secret_access_key'))
-		self._conn = S3Connection(*connection_args)
-		self.bucket = self._conn.get_bucket(bucket)
+		if 'boto3' in sys.modules:
+			if credentials:
+				session = boto3.session.Session(aws_access_key_id=config.get(credentials, 'aws_access_key_id'),
+													  aws_secret_access_key=config.get(credentials, 'aws_secret_access_key'))
+				self._conn = session.resource('s3')
+			else:
+				self._conn = boto3.resource('s3')
+
+			self.bucket = self._conn.Bucket(bucket)
+		else:
+			self._conn = S3Connection(*connection_args)
+			self.bucket = self._conn.get_bucket(bucket)
 
 	def get(self, key, local_file=None):
 		""" See :py:meth:`RigorS3Client.get` """
+		if 'boto3' in sys.modules:
+			return self.__boto3_get__(key, local_file)
+
 		fetched_key = self.bucket.get_key(key)
 		if fetched_key is None:
 			return None
@@ -93,6 +118,9 @@ class BotoS3Client(RigorS3Client):
 
 	def put(self, key, data):
 		""" See :py:meth:`RigorS3Client.put` """
+		if 'boto3' in sys.modules:
+			return self.__boto3_put__(key, data)
+
 		remote_key = Key(self.bucket)
 		remote_key.key = key
 		if hasattr(data, 'read'):
@@ -102,14 +130,66 @@ class BotoS3Client(RigorS3Client):
 
 	def delete(self, key):
 		""" See :py:meth:`RigorS3Client.delete` """
+		if 'boto3' in sys.modules:
+			return self.__boto3_delete__(key)
+
 		remote_key = Key(self.bucket)
 		remote_key.key = key
 		remote_key.delete()
 
 	def list(self, prefix=None):
 		""" See :py:meth:`RigorS3Client.list` """
+		if 'boto3' in sys.modules:
+			return self.__boto3_list__(prefix)
+
 		if prefix is None:
 			prefix = ""
 		return self.bucket.list(prefix=prefix)
+
+	def __boto3_get__(self, key, local_file=None):
+		""" See :py:meth:`RigorS3Client.get` 
+			This implementation is speicfic to Boto3
+		"""
+		s3_obj = BytesIO()
+		try:
+			if local_file is None:
+				self.bucket.download_fileobj(key, s3_obj)
+				s3_obj.seek(0)
+			else:
+				self.bucket.download_file(key, local_file)
+				return True
+		except botocore.exceptions.ClientError as e:
+			return None
+
+		return s3_obj
+
+	def __boto3_put__(self, key, data):
+		""" See :py:meth:`RigorS3Client.put` 
+			This implementation is specific to Boto3
+		"""
+		if hasattr(data, 'read'):
+			self.bucket.upload_fileobj(data, key)
+		else:
+			self.bucket.upload_file(data, key)
+
+	def __boto3_delete__(self, key):
+		""" See :py:meth:`RigorS3Client.delete` 
+			This implementation is specific to Boto3
+		"""
+		delObject = {'Objects': [{'Key': key}]}
+		self.bucket.delete_objects(Delete=delObject)
+
+	def __boto3_list__(self, prefix=None):
+		""" See :py:meth:`RigorS3Client.list` 
+			This implementation is specific to Boto3
+		"""
+		if prefix is None:
+			return self.bucket.objects.all()
+		else:
+			return self.bucket.objects.filter(Prefix=prefix)
+
+
+
+
 
 DefaultS3Client = BotoS3Client

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -83,20 +83,20 @@ class BotoS3Client(RigorS3Client):
 
 	def __init__(self, config, bucket, credentials=None):
 		super(BotoS3Client, self).__init__(config, bucket, credentials)
-		connection_args = list()
-		if credentials:
-			connection_args.append(config.get(credentials, 'aws_access_key_id'))
-			connection_args.append(config.get(credentials, 'aws_secret_access_key'))
 		if 'boto3' in sys.modules:
 			if credentials:
 				session = boto3.session.Session(aws_access_key_id=config.get(credentials, 'aws_access_key_id'),
-													  aws_secret_access_key=config.get(credentials, 'aws_secret_access_key'))
+												aws_secret_access_key=config.get(credentials, 'aws_secret_access_key'))
 				self._conn = session.resource('s3')
 			else:
 				self._conn = boto3.resource('s3')
 
 			self.bucket = self._conn.Bucket(bucket)
 		else:
+			connection_args = list()
+			if credentials:
+				connection_args.append(config.get(credentials, 'aws_access_key_id'))
+				connection_args.append(config.get(credentials, 'aws_secret_access_key'))
 			self._conn = S3Connection(*connection_args)
 			self.bucket = self._conn.get_bucket(bucket)
 

--- a/test/s3.py
+++ b/test/s3.py
@@ -1,8 +1,13 @@
-import boto
-from boto.s3.key import Key
+try:
+	import boto3
+except ImportError:
+	import boto
+	from boto.s3.key import Key
+
 from moto import mock_s3
 import constants
 import os
+import sys
 
 mMock = None
 kKeys = ('s3-key-1', 's3-key-2', 's3-key-3')
@@ -12,12 +17,20 @@ def setup_module(module):
 	mMock = mock_s3()
 	mMock.start()
 
-	conn = boto.connect_s3()
-	bucket = conn.create_bucket(constants.kExampleBucket)
-	for index, key_name in enumerate(kKeys):
-		key = Key(bucket)
-		key.key = key_name
-		key.set_contents_from_string(str(index))
+	if 'boto3' in sys.modules:
+		conn = boto3.resource('s3')
+		bucket = conn.create_bucket(Bucket=constants.kExampleBucket)
+		for index, key_name in enumerate(kKeys):
+			bucket.Object(key_name).put(Body=str(index))
+	else:
+		conn = boto.connect_s3()
+		bucket = conn.create_bucket(constants.kExampleBucket)
+
+		for index, key_name in enumerate(kKeys):
+			key = Key(bucket)
+			key.key = key_name
+			key.set_contents_from_string(str(index))
+
 
 def teardown_module(module):
 	global mMock

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -41,6 +41,9 @@ def test_get_open_file(client):
 			value = contents.read()
 			assert value == str(index)
 
+def test_get_boto_version(client):
+	assert client.boto_version().startswith('boto')
+
 def test_get_missing(client):
 	contents = client.get('xthanteohntahoeaoedhaod')
 	assert contents is None


### PR DESCRIPTION
Added boto3 support to Rigor. Rigor now attempts to load boto3 and if it can not loads boto2. All tests in test/test_s3.py pass. test/s3.py was modified as needed to generate a proper mock object.

Method: 
I created simple private shadow methods in BotoS3Client to keep things simple. Each public method calls the private shadow method if boto3 is loaded.